### PR TITLE
NA Launcher Replacement Improvements

### DIFF
--- a/PSO2Launcher/App.config
+++ b/PSO2Launcher/App.config
@@ -11,7 +11,7 @@
     <userSettings>
         <Dogstar.Properties.Settings>
             <setting name="GameFolder" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="CloseOnLaunch" serializeAs="String">
                 <value>True</value>

--- a/PSO2Launcher/App.config
+++ b/PSO2Launcher/App.config
@@ -11,7 +11,7 @@
     <userSettings>
         <Dogstar.Properties.Settings>
             <setting name="GameFolder" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="CloseOnLaunch" serializeAs="String">
                 <value>True</value>

--- a/PSO2Launcher/CustomSettingsProvider.cs
+++ b/PSO2Launcher/CustomSettingsProvider.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Configuration;
+using System.Reflection;
+using System.Xml.Linq;
+using System.IO;
+
+namespace Dogstar
+{
+    class CustomSettingsProvider : SettingsProvider
+    {
+        const string NAME = "name";
+        const string SERIALIZE_AS = "serializeAs";
+        const string CONFIG = "configuration";
+        const string USER_SETTINGS = "userSettings";
+        const string SETTING = "setting";
+
+        /// <summary>
+        /// Loads the file into memory.
+        /// </summary>
+        public CustomSettingsProvider()
+        {
+            SettingsDictionary = new Dictionary<string, SettingStruct>();
+
+        }
+
+        /// <summary>
+        /// Override.
+        /// </summary>
+        public override void Initialize(string name, System.Collections.Specialized.NameValueCollection config)
+        {
+            base.Initialize(ApplicationName, config);
+        }
+
+        /// <summary>
+        /// Override.
+        /// </summary>
+        public override string ApplicationName
+        {
+            get
+            {
+                return System.Reflection.Assembly.GetExecutingAssembly().ManifestModule.Name;
+            }
+            set
+            {
+                //do nothing
+            }
+        }
+
+        /// <summary>
+        /// Must override this, this is the bit that matches up the designer properties to the dictionary values
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="collection"></param>
+        /// <returns></returns>
+        public override SettingsPropertyValueCollection GetPropertyValues(SettingsContext context, SettingsPropertyCollection collection)
+        {
+            //load the file
+            if (!_loaded)
+            {
+                _loaded = true;
+                LoadValuesFromFile();
+            }
+
+            //collection that will be returned.
+            SettingsPropertyValueCollection values = new SettingsPropertyValueCollection();
+
+            //itterate thought the properties we get from the designer, checking to see if the setting is in the dictionary
+            foreach (SettingsProperty setting in collection)
+            {
+                SettingsPropertyValue value = new SettingsPropertyValue(setting);
+                value.IsDirty = false;
+
+                //need the type of the value for the strong typing
+                var t = Type.GetType(setting.PropertyType.FullName);
+
+                if (SettingsDictionary.ContainsKey(setting.Name))
+                {
+                    value.SerializedValue = SettingsDictionary[setting.Name].value;
+                    value.PropertyValue = Convert.ChangeType(SettingsDictionary[setting.Name].value, t);
+                }
+                else //use defaults in the case where there are no settings yet
+                {
+                    value.SerializedValue = setting.DefaultValue;
+                    value.PropertyValue = Convert.ChangeType(setting.DefaultValue, t);
+                }
+
+                values.Add(value);
+            }
+            return values;
+        }
+
+        /// <summary>
+        /// Must override this, this is the bit that does the saving to file.  Called when Settings.Save() is called
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="collection"></param>
+        public override void SetPropertyValues(SettingsContext context, SettingsPropertyValueCollection collection)
+        {
+            //grab the values from the collection parameter and update the values in our dictionary.
+            foreach (SettingsPropertyValue value in collection)
+            {
+                var setting = new SettingStruct()
+                {
+                    value = (value.PropertyValue == null ? String.Empty : value.PropertyValue.ToString()),
+                    name = value.Name,
+                    serializeAs = value.Property.SerializeAs.ToString()
+                };
+
+                if (!SettingsDictionary.ContainsKey(value.Name))
+                {
+                    SettingsDictionary.Add(value.Name, setting);
+                }
+                else
+                {
+                    SettingsDictionary[value.Name] = setting;
+                }
+            }
+
+            //now that our local dictionary is up-to-date, save it to disk.
+            SaveValuesToFile();
+        }
+
+        /// <summary>
+        /// Loads the values of the file into memory.
+        /// </summary>
+        private void LoadValuesFromFile()
+        {
+            if (!File.Exists(UserConfigPath))
+            {
+                //if the config file is not where it's supposed to be create a new one.
+                CreateEmptyConfig();
+            }
+
+            //load the xml
+            var configXml = XDocument.Load(UserConfigPath);
+
+            //get all of the <setting name="..." serializeAs="..."> elements.
+            var settingElements = configXml.Element(CONFIG).Element(USER_SETTINGS).Element(typeof(Properties.Settings).FullName).Elements(SETTING);
+
+            //iterate through, adding them to the dictionary, (checking for nulls, xml no likey nulls)
+            //using "String" as default serializeAs...just in case, no real good reason.
+            foreach (var element in settingElements)
+            {
+                var newSetting = new SettingStruct()
+                {
+                    name = element.Attribute(NAME) == null ? String.Empty : element.Attribute(NAME).Value,
+                    serializeAs = element.Attribute(SERIALIZE_AS) == null ? "String" : element.Attribute(SERIALIZE_AS).Value,
+                    value = element.Value ?? String.Empty
+                };
+                SettingsDictionary.Add(element.Attribute(NAME).Value, newSetting);
+            }
+        }
+
+        /// <summary>
+        /// Creates an empty user.config file...looks like the one MS creates.  
+        /// This could be overkill a simple key/value pairing would probably do.
+        /// </summary>
+        private void CreateEmptyConfig()
+        {
+            var doc = new XDocument();
+            var declaration = new XDeclaration("1.0", "utf-8", "true");
+            var config = new XElement(CONFIG);
+            var userSettings = new XElement(USER_SETTINGS);
+            var group = new XElement(typeof(Properties.Settings).FullName);
+            userSettings.Add(group);
+            config.Add(userSettings);
+            doc.Add(config);
+            doc.Declaration = declaration;
+            doc.Save(UserConfigPath);
+        }
+
+        /// <summary>
+        /// Saves the in memory dictionary to the user config file
+        /// </summary>
+        private void SaveValuesToFile()
+        {
+            //load the current xml from the file.
+            var import = XDocument.Load(UserConfigPath);
+
+            //get the settings group (e.g. <Company.Project.Desktop.Settings>)
+            var settingsSection = import.Element(CONFIG).Element(USER_SETTINGS).Element(typeof(Properties.Settings).FullName);
+
+            //iterate though the dictionary, either updating the value or adding the new setting.
+            foreach (var entry in SettingsDictionary)
+            {
+                var setting = settingsSection.Elements().FirstOrDefault(e => e.Attribute(NAME).Value == entry.Key);
+                if (setting == null) //this can happen if a new setting is added via the .settings designer.
+                {
+                    var newSetting = new XElement(SETTING);
+                    newSetting.Add(new XAttribute(NAME, entry.Value.name));
+                    newSetting.Add(new XAttribute(SERIALIZE_AS, entry.Value.serializeAs));
+                    newSetting.Value = (entry.Value.value ?? String.Empty);
+                    settingsSection.Add(newSetting);
+                }
+                else //update the value if it exists.
+                {
+                    setting.Value = (entry.Value.value ?? String.Empty);
+                }
+            }
+            import.Save(UserConfigPath);
+        }
+
+        /// <summary>
+        /// The setting key this is returning must set before the settings are used.
+        /// e.g. <c>Properties.Settings.Default.SettingsKey = @"C:\temp\user.config";</c>
+        /// </summary>
+        private string UserConfigPath
+        {
+            get
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "SEGA").ToString() + "\\dogstar.config";
+            }
+
+        }
+
+        /// <summary>
+        /// In memory storage of the settings values
+        /// </summary>
+        private Dictionary<string, SettingStruct> SettingsDictionary { get; set; }
+
+        /// <summary>
+        /// Helper struct.
+        /// </summary>
+        internal struct SettingStruct
+        {
+            internal string name;
+            internal string serializeAs;
+            internal string value;
+        }
+
+        bool _loaded;
+    }
+}

--- a/PSO2Launcher/Dogstar.csproj
+++ b/PSO2Launcher/Dogstar.csproj
@@ -96,6 +96,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="CustomSettingsProvider.cs" />
     <Compile Include="NorthAmericaPatchProvider.cs" />
     <Compile Include="AquaHttpClient.cs">
       <SubType>Component</SubType>
@@ -121,6 +122,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Text.resx</DependentUpon>
     </Compile>
+    <Compile Include="Settings.cs" />
     <Compile Include="TabControler.cs" />
     <Compile Include="UpdateMethod.cs" />
     <Compile Include="FileSelectDialog.xaml.cs">
@@ -182,6 +184,7 @@
     <EmbeddedResource Include="Resources\Text.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Text.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.manifest" />
     <None Include="dogstar.snk" />

--- a/PSO2Launcher/Helper.cs
+++ b/PSO2Launcher/Helper.cs
@@ -128,6 +128,8 @@ namespace Dogstar
 
 		public static bool IsFileUpToDate(string filePath, long targetSize, string targetHash)
 		{
+            if (filePath.Contains("pso2launcher"))
+                return true;
 			try
 			{
 				var info = new FileInfo(filePath);

--- a/PSO2Launcher/MainWindow.xaml
+++ b/PSO2Launcher/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:local="clr-namespace:Dogstar"
         xmlns:properties="clr-namespace:Dogstar.Properties"
         mc:Ignorable="d"
-        Title="{Binding WindowTittle, ElementName=MetroWindow, Mode=OneWay}" Height="540" Width="360" Loaded="metroWindow_Loaded" Icon="Resources/icon.ico" ResizeMode="CanMinimize" LocationChanged="MetroWindow_LocationChanged">
+        Title="{Binding WindowTittle, ElementName=MetroWindow, Mode=OneWay}" Height="482" Width="360" Loaded="metroWindow_Loaded" Icon="Resources/icon.ico" ResizeMode="CanMinimize" LocationChanged="MetroWindow_LocationChanged">
 
     <controls:MetroWindow.Resources>
         <ObjectDataProvider x:Key="Resolutions" ObjectType="{x:Type local:UiResources}" MethodName="GetResolutions"/>
@@ -70,8 +70,8 @@
             <TabItem x:Name="GameTabItem" Header="Game" controls:ControlsHelper.HeaderFontSize="21" DataContext="{Binding Source={StaticResource Resolutions}}">
                 <TabControl x:Name="GameTabControl">
                     <TabItem x:Name="MainTabItem" IsEnabled="False">
-                        <Grid>
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="52,0,52,72" RenderTransformOrigin="0.5,0.5">
+                        <Grid Margin="0,0,0,74">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="50,0,56,-61" RenderTransformOrigin="0.5,0.5">
                                 <StackPanel.RenderTransform>
                                     <TransformGroup>
                                         <ScaleTransform ScaleX="1.5" ScaleY="1.5"/>
@@ -407,157 +407,8 @@
                             <ImageBrush ImageSource="Resources/Icon.ico" Stretch="UniformToFill"/>
                         </controls:ProgressRing.Foreground>
                     </controls:ProgressRing>
-
-                    <Rectangle Margin="150,372,140,66" RenderTransformOrigin="0.024,0.548">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Visual="{StaticResource appbar_arrow_right}"/>
-                        </Rectangle.OpacityMask>
-                        <Rectangle.Effect>
-                            <DropShadowEffect/>
-                        </Rectangle.Effect>
-                        <Rectangle.RenderTransform>
-                            <TransformGroup>
-                                <ScaleTransform/>
-                                <SkewTransform/>
-                                <RotateTransform Angle="94.465"/>
-                                <TranslateTransform X="18.684" Y="-16.381"/>
-                            </TransformGroup>
-                        </Rectangle.RenderTransform>
-                        <Rectangle.Style>
-                            <Style TargetType="{x:Type Rectangle}">
-                                <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                            </Style>
-                        </Rectangle.Style>
-                    </Rectangle>
-
-                    <Rectangle Margin="241,361,43,73" RenderTransformOrigin="0.003,0.535">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Visual="{StaticResource appbar_arrow_right}"/>
-                        </Rectangle.OpacityMask>
-                        <Rectangle.Effect>
-                            <DropShadowEffect/>
-                        </Rectangle.Effect>
-                        <Rectangle.RenderTransform>
-                            <TransformGroup>
-                                <ScaleTransform/>
-                                <SkewTransform/>
-                                <RotateTransform Angle="101.247"/>
-                                <TranslateTransform X="31.341" Y="-24.479"/>
-                            </TransformGroup>
-                        </Rectangle.RenderTransform>
-                        <Rectangle.Style>
-                            <Style TargetType="{x:Type Rectangle}">
-                                <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                            </Style>
-                        </Rectangle.Style>
-                    </Rectangle>
-
-                    <Rectangle Margin="46,360,206,76" RenderTransformOrigin="0.019,0.505">
-                        <Rectangle.OpacityMask>
-                            <VisualBrush Visual="{StaticResource appbar_arrow_right}"/>
-                        </Rectangle.OpacityMask>
-                        <Rectangle.Effect>
-                            <DropShadowEffect/>
-                        </Rectangle.Effect>
-                        <Rectangle.RenderTransform>
-                            <TransformGroup>
-                                <ScaleTransform/>
-                                <SkewTransform/>
-                                <RotateTransform Angle="52.881"/>
-                                <TranslateTransform X="16.696" Y="-28.582"/>
-                            </TransformGroup>
-                        </Rectangle.RenderTransform>
-                        <Rectangle.Style>
-                            <Style TargetType="{x:Type Rectangle}">
-                                <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                            </Style>
-                        </Rectangle.Style>
-                    </Rectangle>
-
-                    <Label Content="Tweet at @DogstarTeam." VerticalAlignment="Center" Margin="98,337,92,85"/>
-                    <Label Content="Live chat on IRC." VerticalAlignment="Center" Margin="227,319,6,103"/>
-                    <Label Content="Report a bug on Github." VerticalAlignment="Center" Margin="-1,311,193,111"/>
                 </Grid>
             </TabItem>
         </TabControl>
-
-        <Rectangle x:Name="Debug" Height="40" Width="40" Margin="67,451,245,18" MouseDown="Debug_MouseDown" ToolTip="Debug Window">
-            <Rectangle.OpacityMask>
-                <VisualBrush Stretch="Uniform" Visual="{StaticResource appbar_bug_remove}"/>
-            </Rectangle.OpacityMask>
-            <Rectangle.Style>
-                <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" Value="{DynamicResource AccentColorBrush}"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Rectangle.Style>
-        </Rectangle>
-        <Rectangle x:Name="Github" Height="40" Width="40" Margin="110,449,202,20" MouseDown="Github_MouseDown" ToolTip="Dogstar Source Code">
-            <Rectangle.OpacityMask>
-                <VisualBrush Stretch="Uniform" Visual="{StaticResource appbar_social_github_octocat_solid}"/>
-            </Rectangle.OpacityMask>
-            <Rectangle.Style>
-                <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" Value="{DynamicResource AccentColorBrush}"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Rectangle.Style>
-        </Rectangle>
-        <Rectangle x:Name="Twitter" Height="40" Width="40" Margin="155,449,157,20" MouseDown="Twitter_MouseDown" ToolTip="TeamDogstar Twitter Account">
-            <Rectangle.OpacityMask>
-                <VisualBrush Stretch="Uniform"
-        			Visual="{StaticResource appbar_twitter_bird}"/>
-            </Rectangle.OpacityMask>
-            <Rectangle.Style>
-                <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" Value="{DynamicResource AccentColorBrush}"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Rectangle.Style>
-        </Rectangle>
-        <Rectangle x:Name="Donate" Height="40" Width="40" Margin="202,447,110,22" MouseDown="Donate_MouseDown" ToolTip="Donate">
-            <Rectangle.OpacityMask>
-                <VisualBrush Stretch="Uniform"
-        			Visual="{StaticResource appbar_money}"/>
-            </Rectangle.OpacityMask>
-            <Rectangle.Style>
-                <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" Value="{DynamicResource AccentColorBrush}"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Rectangle.Style>
-        </Rectangle>
-        <Rectangle x:Name="Information" Height="40" Width="40" Margin="249,445,63,24" MouseDown="Information_MouseDown" ToolTip="Get Information On IRC">
-            <Rectangle.OpacityMask>
-                <VisualBrush Stretch="Uniform"
-        			Visual="{StaticResource appbar_information_circle}"/>
-            </Rectangle.OpacityMask>
-            <Rectangle.Style>
-                <Style TargetType="{x:Type Rectangle}">
-                    <Setter Property="Fill" Value="{DynamicResource AccentColorBrush2}"/>
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Fill" Value="{DynamicResource AccentColorBrush}"/>
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Rectangle.Style>
-        </Rectangle>
     </Grid>
 </controls:MetroWindow>

--- a/PSO2Launcher/MainWindow.xaml.cs
+++ b/PSO2Launcher/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using MahApps.Metro.Controls.Dialogs;
 using Dogstar.Resources;
 using Dogstar.Properties;
 using MahApps.Metro.Controls;
+using System.Reflection;
 
 using static MahApps.Metro.ThemeManager;
 using static Dogstar.Helper;
@@ -172,6 +173,13 @@ namespace Dogstar
 			{
 				string gamefolder = GetTweakerGameFolder();
 
+                if (string.IsNullOrWhiteSpace(gamefolder))
+                {
+                    string Pso2Path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\pso2.exe";
+                    if (File.Exists(Pso2Path))
+                        gamefolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                }
+
 				if (string.IsNullOrWhiteSpace(gamefolder))
 				{
 					await SetupGameInfo();
@@ -226,16 +234,6 @@ namespace Dogstar
 						return client.DownloadStringTaskAsync(x.Url);
 					}
 				}).ToArray();
-
-				if (File.Exists(editionPath))
-				{
-					string edition = await Task.Run(() => File.ReadAllText(editionPath));
-
-					if (edition != "jp")
-					{
-						await this.ShowMessageAsync(Text.Warning, Text.NonJPPSO2);
-					}
-				}
 
 				if (!await patchProvider.IsGameUpToDate())
 				{
@@ -725,12 +723,14 @@ namespace Dogstar
 					string launcherList = await manager.DownloadStringTaskAsync(patchProvider.LauncherListUrl);
 					string patchList    = await manager.DownloadStringTaskAsync(patchProvider.PatchListUrl);
 					string listAlways   = await manager.DownloadStringTaskAsync(patchProvider.PatchListAlwaysUrl);
+                    
 
 					PatchListEntry[] launcherListData = PatchListEntry.Parse(launcherList).ToArray();
 					PatchListEntry[] patchListData    = PatchListEntry.Parse(patchList).ToArray();
 					PatchListEntry[] patchListAlways  = PatchListEntry.Parse(listAlways).ToArray();
+                    
 
-					await RestoreAllPatchBackups();
+                    await RestoreAllPatchBackups();
 
 					if (method == UpdateMethod.Update && Directory.Exists(patchProvider.GameConfigFolder))
 					{
@@ -753,7 +753,8 @@ namespace Dogstar
 							IEnumerable<PatchListEntry> storedAlwaysList = await Task.Run(() => PatchListEntry.Parse(File.ReadAllText(patchProvider.PatchListAlwaysPath)));
 							patchListAlways = patchListAlways.Except(storedAlwaysList, entryComparer).ToArray();
 						}
-					}
+
+                    }
 
 					PatchListEntry[] lists = launcherListData.Concat(patchListData.Concat(patchListAlways)).ToArray();
 					PatchListEntry[] groups = (from v in lists group v by v.Name into d select d.First()).ToArray();

--- a/PSO2Launcher/PatchProvider.cs
+++ b/PSO2Launcher/PatchProvider.cs
@@ -19,8 +19,8 @@ namespace Dogstar
 
 		public string LauncherListPath    => Path.Combine(GameConfigFolder, "launcherlist.txt");
 		public string PatchListPath       => Path.Combine(GameConfigFolder, "_patchlist.txt");
-		public string PatchListAlwaysPath => Path.Combine(GameConfigFolder, "_patchlist_always.txt");
-		public string VersionFilePath     => Path.Combine(GameConfigFolder, "version.ver");
+		public string PatchListAlwaysPath => Path.Combine(GameConfigFolder, "_patchlist_always_win10.txt");
+        public string VersionFilePath     => Path.Combine(GameConfigFolder, "version.ver");
 		public string PrecedeTxtPath      => Path.Combine(GameConfigFolder, "precede.txt");
 
 		// UNDONE: make Settings.Default.GameFolder selectable for region
@@ -35,6 +35,8 @@ namespace Dogstar
 		public Uri LauncherListUrl    { get; private set; }
 		public Uri PatchListUrl       { get; private set; }
 		public Uri PatchListAlwaysUrl { get; private set; }
+        // This probably should be some sort of "editions" array
+        public Uri PatchListWin10Url  { get; private set; }
 		public Uri VersionFileUrl     { get; private set; }
 
 		/// <summary>
@@ -57,7 +59,7 @@ namespace Dogstar
 
 			LauncherListUrl    = new Uri(PatchUrl, "launcherlist.txt");
 			PatchListUrl       = new Uri(PatchUrl, "patchlist.txt");
-			PatchListAlwaysUrl = new Uri(PatchUrl, "patchlist_always.txt");
+			PatchListAlwaysUrl = new Uri(PatchUrl, "patchlist_always_win10.txt");
 			VersionFileUrl     = new Uri(PatchUrl, "version.ver");
 		}
 

--- a/PSO2Launcher/Properties/Settings.Designer.cs
+++ b/PSO2Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Dogstar.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/PSO2Launcher/PsoSettings.cs
+++ b/PSO2Launcher/PsoSettings.cs
@@ -10,6 +10,7 @@ namespace Dogstar
 	{
 		private static readonly Lua LuaVm = new Lua();
 		private static readonly Dictionary<string, dynamic> Cache = new Dictionary<string, dynamic>();
+        private static PatchProvider provider = new NorthAmericaPatchProvider();
 
 		private static bool _isLoaded;
 
@@ -152,7 +153,7 @@ namespace Dogstar
 
 		public static void Reload()
 		{
-			// UNDONE: LuaVm.DoFile(Path.Combine(GameConfigFolder, "user.pso2"));
+			LuaVm.DoFile(Path.Combine(provider.GameConfigFolder, "user.pso2"));
 			_isLoaded = true;
 		}
 
@@ -168,7 +169,7 @@ namespace Dogstar
 			LuaVm.DoString("WrapsIni = {Ini = Ini}");
 			var result = (string)LuaVm.DoString("return to_string(WrapsIni)")[0];
 
-			// UNDONE: File.WriteAllText(Path.Combine(GameConfigFolder, "user.pso2"), result);
+			File.WriteAllText(Path.Combine(provider.GameConfigFolder, "user.pso2"), result);
 		}
 
 	}

--- a/PSO2Launcher/Settings.cs
+++ b/PSO2Launcher/Settings.cs
@@ -1,0 +1,29 @@
+﻿namespace Dogstar.Properties {
+
+
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    [System.Configuration.SettingsProvider(typeof(Dogstar.CustomSettingsProvider))]
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}


### PR DESCRIPTION
- US Patchlist uses win10 always file
- Re-enabled settings file editing
- Stored dogstar config in Documents/SEGA
    - This is needed to make it work when run via UWP sandbox
- Autodetect if PSO2.exe is in the same directory as dogstar to set the path
    - This simplifies launcher replacement